### PR TITLE
Add DBConvert Streams to data integration list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Apache Kafka Connect](https://kafka.apache.org/documentation/#connect) – Framework for moving data between Kafka and external systems.
 - [Apache NiFi](https://nifi.apache.org/) – Visual data ingestion and flow automation platform.
 - [Airbyte](https://airbyte.com/) – Open-source data integration platform for ELT pipelines.
+- [DBConvert Streams](https://streams.dbconvert.com/) - Database migration and CDC replication for PostgreSQL, MySQL, files, and S3.
 - [Fivetran](https://www.fivetran.com/) – Managed data connectors for analytics and warehousing.
 - [Singer](https://www.singer.io/) – Open-source standard for data extraction and loading.
 - [Debezium](https://debezium.io/) – Change data capture (CDC) platform for databases.


### PR DESCRIPTION
Adds DBConvert Streams as a data ingestion/integration tool.

It fits this section because it supports database migration, CDC replication, and data movement across PostgreSQL, MySQL, files, and S3-compatible storage.

The description is kept short and objective to match the existing list style.

## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows the quality and content standards.
- [x] I have not added a link to my own project if it's not notable or widely used.


### Description of the Change

Adds DBConvert Streams to the Data Ingestion & Integration section.

DBConvert Streams fits this category as a database migration and CDC replication tool for PostgreSQL, MySQL, files, and S3-compatible storage.

The entry follows the existing one-line format used by the list.
