### PR TITLE
Add Bruin to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Prefect](https://www.prefect.io/) – Workflow orchestration system for data pipelines.
 - [Luigi](https://github.com/spotify/luigi) – Python package for building complex pipelines.
 - [Argo Workflows](https://argo-workflows.readthedocs.io/) – Kubernetes-native workflow engine.
+- [Bruin](https://github.com/bruin-data/bruin) – CLI that runs ingestion, SQL and Python transformations, and data quality checks as one pipeline.
 
 ## Storage, Warehousing & Lakehouses
 


### PR DESCRIPTION
Adds [Bruin](https://github.com/bruin-data/bruin) to **Workflow Orchestration**.

Bruin is an Apache-2.0 command-line tool that defines a data pipeline as a set of assets and runs it end to end: ingestion, SQL/Python/R transformations, dependency resolution, and column-level data quality checks. It runs locally, on a VM, or in CI, and targets BigQuery, Snowflake, Postgres, Redshift, Databricks, DuckDB, ClickHouse and others.

Written in Go, ~1.7k GitHub stars, documented at https://getbruin.com/docs/bruin/, actively maintained with commits this week.

Checklist:
- [x] Link is active and points to the project repository.
- [x] Fits the scope and category — it is a pipeline orchestration tool, alongside Airflow, Dagster and Prefect.
- [x] Description is short, objective, and matches the existing en-dash format.
- [x] Not a duplicate; no existing entry or open PR for it.
- [x] Single link only — no other entries added.

Disclosure: I work on Bruin, so this is a self-submission rather than a third-party recommendation. Understood that inclusion is at your discretion.